### PR TITLE
132 Remove Extra Whitespace from Homepage

### DIFF
--- a/src/styles/AppWrapper.scss
+++ b/src/styles/AppWrapper.scss
@@ -6,7 +6,7 @@ $header-height: 50px;
 //=======================================
 #app-wrapper {
   background-color: white;
-  margin: $header-height 0 $header-height 0;
+  margin: $header-height 0 0 0;
   min-height: calc(100vh - #{$header-height});
 }
 

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -56,4 +56,5 @@ body {
   font-style: normal;
   font-weight: 400;
   line-height: 29px;
+  margin: 0;
 }


### PR DESCRIPTION
<!--
    Your PR title can should describe what feature was added/changed
-->

## Summary

Closes #132

- Remove the extra whitespace on the sides and the bottom
- Modify the body to have 0 margin and the appwrapper to not have a bottom margin, since we have no footer.

## Screenshots
![image](https://user-images.githubusercontent.com/78634083/219903049-697d1295-5462-45bf-9315-89e8258a6398.png)
