### PR TITLE
151/152 Fix confetti and make box conditionally render

### DIFF
--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -68,9 +68,9 @@ export default function Box(props: BoxProps): JSX.Element {
           {props.conf && (
             <ConfettiExplosion
               force={0.4}
-              duration={2000}
+              duration={5000}
               particleCount={40}
-              height={1000}
+              height={document.documentElement.offsetHeight}
               width={300}
             />
           )}
@@ -130,9 +130,9 @@ export default function Box(props: BoxProps): JSX.Element {
           {props.conf && (
             <ConfettiExplosion
               force={0.4}
-              duration={2000}
+              duration={5000}
               particleCount={100}
-              height={1000}
+              height={document.documentElement.offsetHeight}
               width={300}
             />
           )}
@@ -192,9 +192,9 @@ export default function Box(props: BoxProps): JSX.Element {
           {props.conf && (
             <ConfettiExplosion
               force={0.4}
-              duration={2000}
+              duration={5000}
               particleCount={100}
-              height={1000}
+              height={document.documentElement.offsetHeight}
               width={300}
             />
           )}
@@ -254,9 +254,9 @@ export default function Box(props: BoxProps): JSX.Element {
           {props.conf && (
             <ConfettiExplosion
               force={0.4}
-              duration={2000}
+              duration={5000}
               particleCount={100}
-              height={1000}
+              height={document.documentElement.offsetHeight}
               width={300}
             />
           )}
@@ -316,9 +316,9 @@ export default function Box(props: BoxProps): JSX.Element {
           {props.conf && (
             <ConfettiExplosion
               force={0.4}
-              duration={2000}
+              duration={5000}
               particleCount={100}
-              height={1000}
+              height={document.documentElement.offsetHeight}
               width={300}
             />
           )}
@@ -378,9 +378,9 @@ export default function Box(props: BoxProps): JSX.Element {
           {props.conf && (
             <ConfettiExplosion
               force={0.4}
-              duration={2000}
+              duration={5000}
               particleCount={100}
-              height={1000}
+              height={document.documentElement.offsetHeight}
               width={300}
             />
           )}

--- a/src/components/ShelfAddress.tsx
+++ b/src/components/ShelfAddress.tsx
@@ -1,10 +1,27 @@
-import { useState } from 'react';
+import { useState, SetStateAction, Dispatch } from 'react';
 import '../styles/ShelfAddress.scss';
 
-export default function SomeButton(num: { num: number }): JSX.Element {
-  const [correct, setCorrect] = useState(false);
-  const handleClick = () => {
-    setCorrect(true);
+interface ShelfAddressProps {
+  num: number;
+  handleCorrect: Dispatch<SetStateAction<boolean>>;
+}
+
+export default function ShelfAddress(props: ShelfAddressProps): JSX.Element {
+  const [color, setColor] = useState('#C4C4C4');
+  function timeout(delay: number) {
+    return new Promise((res) => setTimeout(res, delay));
+  }
+
+  const handleClick = async () => {
+    if (color != '#C4C4C4') return;
+    if (props.num == 15) {
+      props.handleCorrect(true);
+      setColor('green');
+      await timeout(2500);
+      props.handleCorrect(false);
+    } else {
+      setColor('red');
+    }
   };
   return (
     <button className={'address'} onClick={handleClick}>
@@ -21,7 +38,7 @@ export default function SomeButton(num: { num: number }): JSX.Element {
             y="1.44511"
             width="38.3946"
             height="38.3946"
-            fill={correct ? 'green' : '#C4C4C4'}
+            fill={color}
             stroke="black"
           />
           <text
@@ -33,7 +50,7 @@ export default function SomeButton(num: { num: number }): JSX.Element {
             dominantBaseline="middle"
             textAnchor="middle"
           >
-            {num.num}
+            {props.num}
           </text>
         </g>
       </svg>

--- a/src/components/ShelfAddress.tsx
+++ b/src/components/ShelfAddress.tsx
@@ -8,17 +8,11 @@ interface ShelfAddressProps {
 
 export default function ShelfAddress(props: ShelfAddressProps): JSX.Element {
   const [color, setColor] = useState('#C4C4C4');
-  function timeout(delay: number) {
-    return new Promise((res) => setTimeout(res, delay));
-  }
-
   const handleClick = async () => {
     if (color != '#C4C4C4') return;
     if (props.num == 15) {
       props.handleCorrect(true);
       setColor('green');
-      await timeout(2500);
-      props.handleCorrect(false);
     } else {
       setColor('red');
     }

--- a/src/pages/Demo.tsx
+++ b/src/pages/Demo.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import Arrow from '../../public/Arrow.png';
 import LeftLadder from '../../public/LeftLadder.png';
 import Pipi from '../../public/Pipi.png';
@@ -6,7 +6,6 @@ import RightLadder from '../../public/RightLadder.png';
 import AlertInbox from '../components/AlertInbox';
 import AppWrapper from '../components/AppWrapper';
 import Box from '../components/Box';
-import Dropdown from '../components/Dropdown';
 import NavButtons from '../components/NavButtons';
 import ShelfAddress from '../components/ShelfAddress';
 import { HeaderSections } from '../types/globalTypes';
@@ -14,6 +13,7 @@ import '../assets/WestwoodSans-Regular.ttf';
 import '../styles/Demo.scss';
 
 const Demo: FC = () => {
+  const [confetti, setConfetti] = useState(false);
   const Popup = (
     <div>
       <div className="address-wrapper">
@@ -319,31 +319,39 @@ const Demo: FC = () => {
     <div>
       <AppWrapper section={HeaderSections.DEMO_SECTION}>
         <div id="layout">
-          <Dropdown
-            options={[
-              { id: 1, name: '1', displayName: '1' },
-              { id: 2, name: '2', displayName: '2' },
-              { id: 3, name: '3', displayName: '3' },
-            ]}
-          />
-
           <p className="description">
             {nums1.map((num) => (
-              <ShelfAddress key={null} num={num}></ShelfAddress>
+              <ShelfAddress
+                key={null}
+                num={num}
+                handleCorrect={setConfetti}
+              ></ShelfAddress>
             ))}
             <br></br>
             {nums2.map((num) => (
-              <ShelfAddress key={null} num={num}></ShelfAddress>
+              <ShelfAddress
+                key={null}
+                num={num}
+                handleCorrect={setConfetti}
+              ></ShelfAddress>
             ))}
             <br></br>
             {nums3.map((num) => (
-              <ShelfAddress key={null} num={num}></ShelfAddress>
+              <ShelfAddress
+                key={null}
+                num={num}
+                handleCorrect={setConfetti}
+              ></ShelfAddress>
             ))}
             <br></br>
           </p>
           <h1 className="header">Demo</h1>
-          <Box letter="a" num={1} conf={false}></Box>
-          <Box letter="b" num={2} conf={true}></Box>
+          <Box letter="a" num={1} conf={confetti}></Box>
+          {confetti ? (
+            <Box letter="b" num={2} conf={true}></Box>
+          ) : (
+            <Box letter="b" num={2} conf={false}></Box>
+          )}
           <Box letter="c" num={3} conf={false}></Box>
           <Box letter="d" num={4} conf={false}></Box>
           <Box letter="e" num={5} conf={false}></Box>


### PR DESCRIPTION
<!--
    Your PR title can should describe what feature was added/changed
-->

## Summary

Closes #151 and #152 and #207

- Set timeout of 2.5 seconds for confetti box to render
- Redid states to make the color of ShelfAddresses change to green only when number is 15 and red otherwise
- Fixed rendering error by deleting Dropdown component

## Screenshots

Definitely one to test yourself. Couldn't figure out how to easily record a screen recording.
<img width="1512" alt="Screenshot 2023-04-30 at 3 00 56 PM" src="https://user-images.githubusercontent.com/78634083/235378065-d8e75320-77fe-4bfb-a60d-cd76224b3ec1.png">
