### PR TITLE
Update Navigation Bar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -148,15 +148,16 @@ export default function Sidebar(props: sidebarProps): JSX.Element {
       <div className="dropdown-header">
         <a href={PageURLs.POINTER_MOTIVATION}>Why Pointers?</a>
       </div>
-      <Dropdown title="Lessons" list={lessonList} />
-      <Dropdown title="Exercises" list={exerciseList} />
       {/* TODO: delete Demo and Error links before production! */}
       <div className="dropdown-header">
         <a href={PageURLs.DEMO}>Demo</a>
       </div>
-      <div className="dropdown-header">
+      <Dropdown title="Lessons" list={lessonList} />
+      <Dropdown title="Exercises" list={exerciseList} />
+      {/* TODO: delete Demo and Error links before production! */}
+      {/* <div className="dropdown-header">
         <a href="/error">Error</a>
-      </div>
+      </div> */}
     </div>
   );
 }

--- a/src/styles/Sidebar.scss
+++ b/src/styles/Sidebar.scss
@@ -37,7 +37,7 @@ $sidebar-width: 357px;
 .dropdown-header {
   color: $text-color;
   cursor: pointer;
-  display: block;
+  display: flex;
   font-family: $play;
   font-size: 24px;
   height: 47px;
@@ -46,6 +46,7 @@ $sidebar-width: 357px;
   padding-right: $padding-h;
   text-align: left;
   transition: 0.3s;
+  align-items: center;
 
   span {
     align-items: center;

--- a/src/styles/Sidebar.scss
+++ b/src/styles/Sidebar.scss
@@ -35,6 +35,7 @@ $sidebar-width: 357px;
 }
 
 .dropdown-header {
+  align-items: center;
   color: $text-color;
   cursor: pointer;
   display: flex;
@@ -46,7 +47,6 @@ $sidebar-width: 357px;
   padding-right: $padding-h;
   text-align: left;
   transition: 0.3s;
-  align-items: center;
 
   span {
     align-items: center;


### PR DESCRIPTION
Updated the Navbar to follow the order
given by PageOrder in globalTypes.ts

Update Navbar Navigation Order

## Summary

Closes #305

- Switched two divs in order to accurately represent the order of pages given by PageOrder
<!-- list any new dependencies required for this change -->

## Screenshots

<!--
    Add Screenshots of the feature in play, terminal pastes, etc. as necessary
-->

<img width="362" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/104863284/91871e66-cd57-40e6-b0e7-2f6ae973d723">
