### PR TITLE
Updated CodeDiagram.scss

### DIFF
--- a/src/styles/CodeDiagram.scss
+++ b/src/styles/CodeDiagram.scss
@@ -53,10 +53,15 @@
   margin: 0.5em;
   padding: 5px 10px;
   width: fit-content;
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .arrow {
   position: relative;
+  width: 50%;
 }
 
 @media screen and (max-width: 1024px) {


### PR DESCRIPTION
Added pointer when hovering a code snippet.
Also fixed it so the code is 50/50 with the
arrow diagrams.

<!--
    Your PR title can should describe what feature was added/changed
-->

## Summary
- I got it to be 50% on a 1440 screen or bigger:
- It still wraps when its a smaller screen and I added the change to a pointer to the box.

Closes #316 

<!-- Enumerate changes you made and why you made them in bullet form-->
<!-- list any new dependencies required for this change -->

## Screenshots
<img width="1208" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/104863284/0cafc240-5311-486a-93d3-018a5c32f503">
<!--
    Add Screenshots of the feature in play, terminal pastes, etc. as necessary
-->
