### PR TITLE
Added animation to FillArrow

### DIFF
--- a/src/components/FillArrow.tsx
+++ b/src/components/FillArrow.tsx
@@ -1,6 +1,5 @@
 import { useRef, useEffect, useMemo, useState } from 'react';
 import '../styles/FillArrow.scss';
-import { VscDebugRestart } from 'react-icons/vsc';
 
 interface FillArrowProps {
   text1: string;

--- a/src/components/FillArrow.tsx
+++ b/src/components/FillArrow.tsx
@@ -1,3 +1,4 @@
+import { useRef, useEffect, useMemo, useState } from 'react';
 import '../styles/FillArrow.scss';
 
 interface FillArrowProps {
@@ -5,9 +6,35 @@ interface FillArrowProps {
   text2: string;
 }
 
+function useIsInViewport(ref) {
+  const [isIntersecting, setIsIntersecting] = useState(false);
+
+  const observer = useMemo(
+    () =>
+      new IntersectionObserver(([entry]) =>
+        setIsIntersecting(entry.isIntersecting)
+      ),
+    []
+  );
+
+  useEffect(() => {
+    observer.observe(ref.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref, observer]);
+
+  return isIntersecting;
+}
+
 function FillArrow(props: FillArrowProps): JSX.Element {
+  const ref = useRef(null);
+
+  const isInViewport = useIsInViewport(ref);
+
   return (
-    <>
+    <div ref={ref}>
       <span className="fill-arrow-container">
         <div className="fill-arrow">
           <div
@@ -20,12 +47,14 @@ function FillArrow(props: FillArrowProps): JSX.Element {
               viewBox="0 0 415 121"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
+              className={isInViewport ? 'arrow-animation' : ''}
             >
               <clipPath id="arrow">
                 <path
                   fillRule="evenodd"
                   clipRule="evenodd"
                   d="M7 2C4.23858 2 2 4.23858 2 7V114C2 116.761 4.23857 119 7 119H247C249.761 119 252 116.761 252 114V75.5H344.885V98L410 60.5L344.885 23V44.5H252V7C252 4.23858 249.761 2 247 2H7Z"
+                  className="arrow-animation"
                 />
               </clipPath>
               <path
@@ -61,6 +90,7 @@ function FillArrow(props: FillArrowProps): JSX.Element {
               viewBox="0 0 250 117"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
+              className={isInViewport ? 'box-animation' : ''}
             >
               <clipPath id="box">
                 <rect
@@ -108,7 +138,7 @@ function FillArrow(props: FillArrowProps): JSX.Element {
           <p id="arrow-text">{props.text2}</p>
         </div>
       </span>
-    </>
+    </div>
   );
 }
 

--- a/src/components/FillArrow.tsx
+++ b/src/components/FillArrow.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useMemo, useState } from 'react';
 import '../styles/FillArrow.scss';
+import { VscDebugRestart } from 'react-icons/vsc';
 
 interface FillArrowProps {
   text1: string;
@@ -33,8 +34,15 @@ function FillArrow(props: FillArrowProps): JSX.Element {
 
   const isInViewport = useIsInViewport(ref);
 
+  const [animate, setAnimate] = useState(false);
+
+  useEffect(() => {
+    if (isInViewport && !animate) setAnimate(true);
+  }, [isInViewport, animate]);
+
   return (
-    <div ref={ref}>
+    <div ref={ref} className="overall-container">
+      <VscDebugRestart className="reset" onClick={() => setAnimate(false)} />
       <span className="fill-arrow-container">
         <div className="fill-arrow">
           <div
@@ -47,7 +55,7 @@ function FillArrow(props: FillArrowProps): JSX.Element {
               viewBox="0 0 415 121"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
-              className={isInViewport ? 'arrow-animation' : ''}
+              className={animate ? 'arrow-animation' : ''}
             >
               <clipPath id="arrow">
                 <path
@@ -90,7 +98,7 @@ function FillArrow(props: FillArrowProps): JSX.Element {
               viewBox="0 0 250 117"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
-              className={isInViewport ? 'box-animation' : ''}
+              className={animate ? 'box-animation' : ''}
             >
               <clipPath id="box">
                 <rect

--- a/src/components/FillArrow.tsx
+++ b/src/components/FillArrow.tsx
@@ -42,7 +42,6 @@ function FillArrow(props: FillArrowProps): JSX.Element {
 
   return (
     <div ref={ref} className="overall-container">
-      <VscDebugRestart className="reset" onClick={() => setAnimate(false)} />
       <span className="fill-arrow-container">
         <div className="fill-arrow">
           <div

--- a/src/styles/FillArrow.scss
+++ b/src/styles/FillArrow.scss
@@ -1,5 +1,12 @@
 @import './global';
 
+.overall-container {
+  display: flex;
+  flex-direction: row-reverse;
+  gap: 2rem;
+  justify-content: center;
+}
+
 .fill-arrow-container {
   display: flex;
   gap: 10px;
@@ -41,14 +48,14 @@
 
 .arrow-animation {
   animation: arrow-box 2s linear;
-  background: linear-gradient(to right, #fec900 50%, yellow 50%);
+  background: linear-gradient(to right, white 50%, #fec900 50%);
   background-position: left;
   background-size: 200% 100%;
 }
 
 .box-animation {
   animation: arrow-box 2s linear forwards;
-  animation-delay: 2s;
+  animation-delay: 1.9s;
   background: linear-gradient(to right, white 50%, #fec900 50%);
   background-position: left;
   background-size: 200% 100%;
@@ -77,5 +84,15 @@
     );
     background-position: left;
     background-size: 200% 100%;
+  }
+}
+
+.reset {
+  position: relative;
+  // left: 5rem;
+
+  &:hover {
+    color: blue;
+    cursor: pointer;
   }
 }

--- a/src/styles/FillArrow.scss
+++ b/src/styles/FillArrow.scss
@@ -86,13 +86,3 @@
     background-size: 200% 100%;
   }
 }
-
-.reset {
-  position: relative;
-  // left: 5rem;
-
-  &:hover {
-    color: blue;
-    cursor: pointer;
-  }
-}

--- a/src/styles/FillArrow.scss
+++ b/src/styles/FillArrow.scss
@@ -38,3 +38,44 @@
   transform: translate(-80px);
   z-index: 2;
 }
+
+.arrow-animation {
+  animation: arrow-box 2s linear;
+  background: linear-gradient(to right, #fec900 50%, yellow 50%);
+  background-position: left;
+  background-size: 200% 100%;
+}
+
+.box-animation {
+  animation: arrow-box 2s linear forwards;
+  animation-delay: 2s;
+  background: linear-gradient(to right, white 50%, #fec900 50%);
+  background-position: left;
+  background-size: 200% 100%;
+}
+
+@keyframes arrow-box {
+  0% {
+    background: linear-gradient(
+      to right,
+      #fec900 0%,
+      #fec900 50%,
+      white 50%,
+      white 100%
+    );
+    background-position: right;
+    background-size: 200% 100%;
+  }
+
+  100% {
+    background: linear-gradient(
+      to right,
+      #fec900 0%,
+      #fec900 50%,
+      white 50%,
+      white 100%
+    );
+    background-position: left;
+    background-size: 200% 100%;
+  }
+}


### PR DESCRIPTION
Added the animation of left to right in
FillArrow. The logic can be copied over to
other .scss files if you want to animate the background.

<!--
    Your PR title can should describe what feature was added/changed
-->

## Summary

Closes #163

<!-- Enumerate changes you made and why you made them in bullet form-->
<!-- list any new dependencies required for this change -->
- Added animation from left to right
- Prompted GPT For this:
  - I want to use CSS to animate the color of a div from left to right, i have this snippet of code that changes the color
  of the div but it changes it in the entirety. Can i use this code to achieve my goal?
  @keyframes example {
  from {background-color: red;}
  to {background-color: yellow;}
  }
- Also made it so that it animates when it is in the viewport
  - https://bobbyhadz.com/blog/react-check-if-element-in-viewport

## Screenshots

<!--
    Add Screenshots of the feature in play, terminal pastes, etc. as necessary
-->

https://github.com/uclaacm/parcel-pointers/assets/104863284/84f55927-61f9-4d87-974d-12e4a74a143f


