### PR TITLE
updated pipi image source

### DIFF
--- a/src/pages/Demo.tsx
+++ b/src/pages/Demo.tsx
@@ -1,7 +1,7 @@
 import { FC, useState } from 'react';
 import Arrow from '../../public/Arrow.png';
 import LeftLadder from '../../public/LeftLadder.png';
-import Pipi from '../../public/Pipi.png';
+import Pipi from '../../public/Pipi.svg';
 import RightLadder from '../../public/RightLadder.png';
 import AlertInbox from '../components/AlertInbox';
 import AppWrapper from '../components/AppWrapper';

--- a/src/pages/PointerMotivation.tsx
+++ b/src/pages/PointerMotivation.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import Pipi from '../../public/Pipi.png';
+import Pipi from '../../public/Pipi.svg';
 import Slideshow from '../../public/Slideshow.png';
 import AppWrapper from '../components/AppWrapper';
 import NavButtons from '../components/NavButtons';


### PR DESCRIPTION
## Summary

- Updated image sources in 2 files
Closes #329 

## Screenshots
### Before:
<img width="318" alt="Screenshot 2023-10-21 at 9 28 44 PM" src="https://github.com/uclaacm/parcel-pointers/assets/70074725/e2414eeb-23ee-4f51-a855-f2c5681266f6">

### After:
<img width="256" alt="Screenshot 2023-10-21 at 9 29 42 PM" src="https://github.com/uclaacm/parcel-pointers/assets/70074725/3c1f5194-9253-43c4-8b04-3a28a46a6cdb">