### PR TITLE
370 fix overlap for small screens

### DIFF
--- a/src/styles/CompareCode.scss
+++ b/src/styles/CompareCode.scss
@@ -9,7 +9,7 @@
   .left-code {
     float: left;
     margin: auto;
-    max-width: 50%;
+    max-width: 49%;
     position: relative;
     @media screen and (min-width: 1400px) {
       left: 12%;
@@ -19,7 +19,7 @@
   .right-code {
     float: right;
     margin: 10 0;
-    max-width: 50%;
+    max-width: 49%;
     position: relative;
     @media screen and (min-width: 1400px) {
       right: 12%;

--- a/src/styles/CompareCode.scss
+++ b/src/styles/CompareCode.scss
@@ -8,21 +8,28 @@
 
   .left-code {
     float: left;
-    left: 10%;
     margin: auto;
     max-width: 50%;
     position: relative;
+    @media screen and (min-width: 1400px) {
+      left: 12%;
+    }
   }
 
   .right-code {
     float: right;
-    margin: 10 0 10 50px;
+    margin: 10 0 10 0px;
     max-width: 50%;
     position: relative;
-    right: 10%;
+    @media screen and (min-width: 1400px) {
+      right: 12%;
+    }
   }
 }
 
 .caption {
   color: $primary-1-color;
+  @media screen and (max-width: 600px) {
+    font-size: 20px !important;
+  }
 }

--- a/src/styles/CompareCode.scss
+++ b/src/styles/CompareCode.scss
@@ -18,7 +18,7 @@
 
   .right-code {
     float: right;
-    margin: 10 0 10 0px;
+    margin: 10 0;
     max-width: 50%;
     position: relative;
     @media screen and (min-width: 1400px) {


### PR DESCRIPTION
<!--
    Your PR title can should describe what feature was added/changed
-->

## Summary

Closes #370 

<!-- Enumerate changes you made and why you made them in bullet form-->
<!-- list any new dependencies required for this change -->

- Move the two blocks of code closer for large screens but not for smaller ones
- Shrink size of caption text on very small screens (mobile)
- Make width max at 49% so that there is always some white space in between the blocks

## Screenshots

<!--
    Add Screenshots of the feature in play, terminal pastes, etc. as necessary
-->
Mobile
![image](https://github.com/uclaacm/parcel-pointers/assets/78634083/053131e3-3db1-4ac4-be7e-7837a096cf46)
![image](https://github.com/uclaacm/parcel-pointers/assets/78634083/8f4567d7-b7f2-4b58-853d-1d7ffc139d37)

PC
![image](https://github.com/uclaacm/parcel-pointers/assets/78634083/eddfbbcf-a08c-437c-b394-6860f13ac03c)
![image](https://github.com/uclaacm/parcel-pointers/assets/78634083/f47240d0-f55a-48ea-9297-3a057f9a97af)


