### PR TITLE
367 fix mobile home page

### DIFF
--- a/src/styles/Home.scss
+++ b/src/styles/Home.scss
@@ -89,7 +89,7 @@ p {
   }
 
   @media only screen and (max-width: 750px) {
-      display: none;
+    display: none;
   }
 }
 

--- a/src/styles/Home.scss
+++ b/src/styles/Home.scss
@@ -87,6 +87,10 @@ p {
   .pp-wrapper {
     margin-right: 3.024%;
   }
+
+  @media only screen and (max-width: 750px) {
+      display: none;
+  }
 }
 
 @keyframes scroll {


### PR DESCRIPTION
<!--
    Your PR title can should describe what feature was added/changed
-->

## Summary

Closes #367  

<!-- Enumerate changes you made and why you made them in bullet form-->

I've identified that the image isn't resizing properly, and a quick solution to this issue would be to set the image display to "None" when the screen is small. This is because, on the homepage, scrolling is disabled, and displaying both text and image on small screens could be difficult.

<!-- list any new dependencies required for this change -->

## Screenshots


Here, you can see what the new changes would look like on a small and compact device, such as the iPhone SE.
<img width="370" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/80062217/6ac1cdfd-985d-43de-8bdc-5585d4cfde4a">

And this is what it looks like on an iPhone 12 Pro.
<img width="339" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/80062217/c7b655d2-c22c-45af-9b03-621a8a6a1896">


Obviously, on a screen larger than 750 pixels in width, the home screen remains the same.
<img width="612" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/80062217/109ad941-1f16-442e-b46a-9953c5814632">


<!--
    Add Screenshots of the feature in play, terminal pastes, etc. as necessary
-->
