### PR TITLE
Added media queries for landscape and portrait on mobile

### DIFF
--- a/src/styles/FillArrow.scss
+++ b/src/styles/FillArrow.scss
@@ -46,6 +46,27 @@
   z-index: 2;
 }
 
+/* Mobile styles */
+// Landscape
+@media screen and (max-width: 769px) {
+  .fill-arrow-container {
+    transform: scale(0.7);
+  }
+  .fill-arrow {
+    font-size: 32px;
+  }
+}
+// Portrait
+@media screen and (max-width: 478px) {
+  .fill-arrow-container {
+    transform: scale(0.4);
+    height: 10vh;
+  }
+  .fill-arrow {
+    font-size: 48px;
+  }
+}
+
 .arrow-animation {
   animation: arrow-box 2.5s linear;
   background: linear-gradient(to right, white 50%, #fec900 50%);


### PR DESCRIPTION
<!--
    Your PR title can should describe what feature was added/changed
-->

## Summary

Closes #369

<!-- Enumerate changes you made and why you made them in bullet form-->

- scaled down fillArrow containers so the arrow diagrams will not extend offscreen on mobile
- increased font-size to compensate for scaled down containers (may have to decrease font-size a little?)
- changed height of diagram to better fit portrait mobile screens

<!-- list any new dependencies required for this change -->

## Screenshots

Portrait:
<img width="721" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/143306913/a001eae3-2a7a-46d8-8dcf-d45776e4e2ca">

Landscape:
<img width="755" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/143306913/bb8d1405-a0ec-43b3-ba79-02d6bcba3519">

<!--
    Add Screenshots of the feature in play, terminal pastes, etc. as necessary
-->
