### PR TITLE
369 scale fill arrow mobile

### DIFF
--- a/src/styles/FillArrow.scss
+++ b/src/styles/FillArrow.scss
@@ -52,6 +52,7 @@
   .fill-arrow-container {
     transform: scale(0.7);
   }
+
   .fill-arrow {
     font-size: 32px;
   }
@@ -59,9 +60,10 @@
 // Portrait
 @media screen and (max-width: 478px) {
   .fill-arrow-container {
-    transform: scale(0.4);
     height: 10vh;
+    transform: scale(0.4);
   }
+
   .fill-arrow {
     font-size: 48px;
   }

--- a/src/styles/FillArrow.scss
+++ b/src/styles/FillArrow.scss
@@ -46,6 +46,27 @@
   z-index: 2;
 }
 
+/* Mobile styles */
+// Landscape
+@media screen and (max-width: 769px) {
+  .fill-arrow-container {
+    transform: scale(0.7);
+  }
+  .fill-arrow {
+    font-size: 32px;
+  }
+}
+// Portrait
+@media screen and (max-width: 478px) {
+  .fill-arrow-container {
+    transform: scale(0.4);
+    height: 10vh;
+  }
+  .fill-arrow {
+    font-size: 48px;
+  }
+}
+
 .arrow-animation {
   animation: arrow-box 2.5s linear;
   background: linear-gradient(to right, white 50%, #fec900 50%);


### PR DESCRIPTION
<!--
    Your PR title can should describe what feature was added/changed
-->

## Summary

Closes #369

<!-- Enumerate changes you made and why you made them in bullet form-->

- added media queries for portrait and landscape on mobile to scale down fillArrow diagrams as to not extend offscreen
- increased font-size to compensate for the font-size getting shrunk down along with the diagrams (may need to decrease font-size a little)
- adjusted height for portrait mobile to prevent excess whitespace

<!-- list any new dependencies required for this change -->

## Screenshots

Portrait:
<img width="721" alt="Screenshot 2024-01-21 at 9 58 36 PM" src="https://github.com/uclaacm/parcel-pointers/assets/143306913/75ec41fc-371c-41b4-baee-c9dc00236d33">

Landscape:
<img width="755" alt="Screenshot 2024-01-21 at 10 00 12 PM" src="https://github.com/uclaacm/parcel-pointers/assets/143306913/deb246f4-cada-4211-81b1-ec8445996835">

<!--
    Add Screenshots of the feature in play, terminal pastes, etc. as necessary
-->
