### PR TITLE
Use grid display to fix display in small screen of the exercise 1

### DIFF
--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -67,7 +67,7 @@ function Question(props: QuestionProps): JSX.Element {
           />
           <div className="question-text-wrapper">{props.children}</div>
         </div>
-        <div className="question-wrapper">
+        <div className="button-wrapper">
           {correct ? (
             expand ? (
               <div onClick={() => setExpand(!expand)}>

--- a/src/pages/Exercise1.tsx
+++ b/src/pages/Exercise1.tsx
@@ -42,18 +42,21 @@ const Exercise1: FC = () => {
             >
               <p className="question-text">
                 The address of the Box b is&nbsp;
-                <span className="dropdown-wrapper">
-                  <Dropdown
-                    options={[
-                      { id: 1, name: '10', displayName: '10' },
-                      { id: 2, name: '11', displayName: '11' },
-                      { id: 3, name: '12', displayName: '12' },
-                      { id: 4, name: '13', displayName: '13' },
-                    ]}
-                    correctAnswer={correctAnswer}
-                    index={0}
-                  />
-                </span>
+                <span className="dropdown-between-text-wrapper">
+                  <span className="dropdown-wrapper">
+                    <Dropdown
+                      options={[
+                        { id: 1, name: '10', displayName: '10' },
+                        { id: 2, name: '11', displayName: '11' },
+                        { id: 3, name: '12', displayName: '12' },
+                        { id: 4, name: '13', displayName: '13' },
+                      ]}
+                      correctAnswer={correctAnswer}
+                      index={0}
+                    />
+                  </span>
+                </span>{' '}
+                .
               </p>
             </Question>
             <Question
@@ -95,18 +98,21 @@ const Exercise1: FC = () => {
             >
               <p className="question-text">
                 The address of the Box e is&nbsp;
-                <span className="dropdown-wrapper">
-                  <Dropdown
-                    options={[
-                      { id: 1, name: '20', displayName: '20' },
-                      { id: 2, name: '21', displayName: '21' },
-                      { id: 3, name: '22', displayName: '22' },
-                      { id: 4, name: '23', displayName: '23' },
-                    ]}
-                    correctAnswer={correctAnswer}
-                    index={2}
-                  />
-                </span>
+                <span className="dropdown-between-text-wrapper">
+                  <span className="dropdown-wrapper">
+                    <Dropdown
+                      options={[
+                        { id: 1, name: '20', displayName: '20' },
+                        { id: 2, name: '21', displayName: '21' },
+                        { id: 3, name: '22', displayName: '22' },
+                        { id: 4, name: '23', displayName: '23' },
+                      ]}
+                      correctAnswer={correctAnswer}
+                      index={2}
+                    />
+                  </span>
+                </span>{' '}
+                .
               </p>
             </Question>
             <Question

--- a/src/styles/Question.scss
+++ b/src/styles/Question.scss
@@ -4,12 +4,23 @@
   border-radius: 10px;
   box-shadow: 0 4px 25px rgba(0, 0, 0, 0.1);
   padding: 30px;
+
+  @media only screen and (max-width: 850px) {
+    align-items: center;
+    justify-items: center;
+  }
 }
 
 .question-container-wrapper {
   align-items: center;
   display: flex;
   justify-content: space-between;
+
+  @media only screen and (max-width: 850px) {
+    align-items: center;
+    display: grid;
+    justify-items: center;
+  }
 }
 
 .question-wrapper {
@@ -17,6 +28,37 @@
   display: flex;
   justify-content: space-between;
   padding-right: 21px;
+
+  @media only screen and (max-width: 850px) {
+    align-items: center;
+    display: grid;
+    justify-items: center;
+    padding-right: 0;
+  }
+}
+
+.button-wrapper {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding-right: 21px;
+
+  @media only screen and (max-width: 850px) {
+    align-items: center;
+    display: grid;
+    justify-items: center;
+    padding-top: 15px;
+  }
+}
+
+.question-text-wrapper {
+  @media only screen and (max-width: 850px) {
+    align-items: center;
+    display: flex;
+    justify-items: center;
+    padding-top: 10px;
+    text-align: center;
+  }
 }
 
 .icon {
@@ -76,4 +118,7 @@
   justify-content: center;
   padding-left: 58px;
   padding-top: 20px;
+  @media only screen and (max-width: 850px) {
+    padding-left: 0;
+  }
 }


### PR DESCRIPTION
<!--
    Your PR title can should describe what feature was added/changed
-->
## Summary

Closes #373 

<!-- Enumerate changes you made and why you made them in bullet form-->
<!-- list any new dependencies required for this change -->
I utilized a grid display to arrange all divs in a stacked format for screens smaller than 850px. Additionally, I adjusted the padding to optimize the layout for smaller screens.

## Screenshots

<!--
    Add Screenshots of the feature in play, terminal pastes, etc. as necessary
-->

Some screenshots of the final results on small screen such as in a iphone SE.

No check buttons pressed
<img width="250" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/80062217/bd788734-c72c-47b6-aae9-3eda1ccb8f38">
Incorrect answer
<img width="238" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/80062217/3147d2b3-90ec-4e9f-8662-e950282bbfcd">
Correct answer
<img width="247" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/80062217/8eefb33c-9a1a-4923-b646-3a81d1e56811">
All correct answer
<img width="236" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/80062217/a8366bb6-825c-40bd-b526-5eade374fc62">


Some screeshots on bigger displays
Iphone 14 pro max
<img width="279" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/80062217/a89055ac-6627-49d8-aa4a-18745f6644cd">
<img width="274" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/80062217/f9b444b3-0b94-4e92-ab37-62bcd338b9cc">
<img width="264" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/80062217/3cf7be40-6f3e-44f9-a1b4-ecc5cc28c1db">


Laptop or tablet displays reamains as before
<img width="528" alt="image" src="https://github.com/uclaacm/parcel-pointers/assets/80062217/61fecfd1-62cf-4b02-902b-ac01dbc89c96">




